### PR TITLE
Fix docName handling in /start

### DIFF
--- a/server/serverModules/backend.js
+++ b/server/serverModules/backend.js
@@ -142,8 +142,8 @@ app.get('/start', async (req, res) => {
   try {
     // 1. Baixa PDF original
     const original = await downloadNode(nodeId);
-    const docName = req.query.docName?.trim();
-    const fileName = docName;
+    const docName = (req.query.docName || '').trim();
+    const fileName = docName || `node_${nodeId}.pdf`;
     const filePath = path.join(INP_ROOT, fileName);
     fs.writeFileSync(filePath, original);
 


### PR DESCRIPTION
## Summary
- avoid crash when `docName` query parameter is missing

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_683f50437cd08326aea78e3a3f456148